### PR TITLE
Add initial unit tests for asset-watcher

### DIFF
--- a/asset-watcher.code-workspace
+++ b/asset-watcher.code-workspace
@@ -23,7 +23,8 @@
             "ldflags",
             "notif",
             "staticcheck",
-            "structpb"
+            "structpb",
+            "timestamppb"
         ],
         "cSpell.ignorePaths": [
             ".golangci.yaml",

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Helper to set environment variables and register cleanup.
+func setEnvVar(t *testing.T, key, value string) {
+	t.Helper()
+	originalValue, originalExists := os.LookupEnv(key)
+	if err := os.Setenv(key, value); err != nil {
+		t.Fatalf("Failed to set env var %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if originalExists {
+			if err := os.Setenv(key, originalValue); err != nil {
+				t.Errorf("Failed to restore env var %s: %v", key, err)
+			}
+		} else {
+			if err := os.Unsetenv(key); err != nil {
+				t.Errorf("Failed to unset env var %s: %v", key, err)
+			}
+		}
+	})
+}
+
+// Helper to clear environment variables and register cleanup.
+func clearEnvVar(t *testing.T, key string) {
+	t.Helper()
+	originalValue, originalExists := os.LookupEnv(key)
+	// No need to check error for Unsetenv, it's fine if it's not set.
+	_ = os.Unsetenv(key)
+	t.Cleanup(func() {
+		if originalExists {
+			if err := os.Setenv(key, originalValue); err != nil {
+				t.Errorf("Failed to restore env var %s after clearing: %v", key, err)
+			}
+		}
+	})
+}
+
+// TestGetConfig_Defaults tests the default values for non-required fields.
+// Required fields must be set for GetConfig not to call log.Fatalf.
+func TestGetConfig_Defaults(t *testing.T) {
+	// Clear optional environment variables
+	clearEnvVar(t, "ASSET_WATCHER_DEBUG")
+	clearEnvVar(t, "ASSET_WATCHER_OUTPUT_FORMAT")
+	clearEnvVar(t, "ASSET_WATCHER_EXCLUDE_RESERVED")
+	clearEnvVar(t, "ASSET_WATCHER_EXCLUDE_PROJECTS")
+	clearEnvVar(t, "ASSET_WATCHER_INCLUDE_PROJECTS")
+
+	// Set required environment variables
+	setEnvVar(t, "ASSET_WATCHER_ORG_ID", "test-org-id-defaults")
+
+	// Defer cleanup of required var if it wasn't set before this test
+	defer clearEnvVar(t, "ASSET_WATCHER_ORG_ID")
+
+
+	cfg := GetConfig() // GetConfig calls log.Fatalf on error if ORG_ID is missing
+
+	if cfg.OrgID != "test-org-id-defaults" {
+		t.Errorf("Expected OrgID to be 'test-org-id-defaults', got '%s'", cfg.OrgID)
+	}
+	if cfg.Debug != false {
+		t.Errorf("Expected Debug default to be false, got %t", cfg.Debug)
+	}
+	if cfg.OutputFormat != "table" {
+		t.Errorf("Expected OutputFormat default to be 'table', got '%s'", cfg.OutputFormat)
+	}
+	if cfg.ExcludeReserved != false {
+		t.Errorf("Expected ExcludeReserved default to be false, got %t", cfg.ExcludeReserved)
+	}
+	if cfg.ExcludeProjects != "" {
+		t.Errorf("Expected ExcludeProjects default to be empty string, got '%s'", cfg.ExcludeProjects)
+	}
+	if cfg.IncludeProjects != "" {
+		t.Errorf("Expected IncludeProjects default to be empty string, got '%s'", cfg.IncludeProjects)
+	}
+}
+
+// TestGetConfig_LoadFromEnv tests loading configuration from environment variables.
+func TestGetConfig_LoadFromEnv(t *testing.T) {
+	expectedConfig := Config{
+		OrgID:           "env-org-id",
+		Debug:           true,
+		OutputFormat:    "json",
+		ExcludeReserved: true,
+		ExcludeProjects: "proj1,proj2",
+		IncludeProjects: "", // Will be empty as ExcludeProjects is set
+	}
+
+	setEnvVar(t, "ASSET_WATCHER_ORG_ID", expectedConfig.OrgID)
+	setEnvVar(t, "ASSET_WATCHER_DEBUG", "true")
+	setEnvVar(t, "ASSET_WATCHER_OUTPUT_FORMAT", expectedConfig.OutputFormat)
+	setEnvVar(t, "ASSET_WATCHER_EXCLUDE_RESERVED", "true")
+	setEnvVar(t, "ASSET_WATCHER_EXCLUDE_PROJECTS", expectedConfig.ExcludeProjects)
+	clearEnvVar(t, "ASSET_WATCHER_INCLUDE_PROJECTS") // Ensure include is not set
+
+	cfg := GetConfig()
+
+	if !reflect.DeepEqual(*cfg, expectedConfig) {
+		t.Errorf("Expected config %+v, got %+v", expectedConfig, *cfg)
+	}
+}
+
+func TestGetConfig_LoadFromEnv_Include(t *testing.T) {
+	expectedConfig := Config{
+		OrgID:           "env-org-id-include",
+		Debug:           false, // Testing explicit false
+		OutputFormat:    "table", // Testing explicit table
+		ExcludeReserved: false, // Testing explicit false
+		ExcludeProjects: "", 
+		IncludeProjects: "proj3,proj4",
+	}
+
+	setEnvVar(t, "ASSET_WATCHER_ORG_ID", expectedConfig.OrgID)
+	setEnvVar(t, "ASSET_WATCHER_DEBUG", "false")
+	setEnvVar(t, "ASSET_WATCHER_OUTPUT_FORMAT", "table")
+	setEnvVar(t, "ASSET_WATCHER_EXCLUDE_RESERVED", "false")
+	clearEnvVar(t, "ASSET_WATCHER_EXCLUDE_PROJECTS")
+	setEnvVar(t, "ASSET_WATCHER_INCLUDE_PROJECTS", expectedConfig.IncludeProjects)
+
+	cfg := GetConfig()
+
+	if !reflect.DeepEqual(*cfg, expectedConfig) {
+		t.Errorf("Expected config %+v, got %+v", expectedConfig, *cfg)
+	}
+}
+
+// runTestExpectingFatal is a helper to test functions that should call log.Fatalf
+func runTestExpectingFatal(t *testing.T, testName string, setupFunc func()) {
+	t.Helper()
+	// Check if we are in the subprocess
+	if os.Getenv("BE_FATAL_TESTER") == "1" {
+		setupFunc() // Setup env vars for the specific test case
+		GetConfig() // This should call log.Fatalf and exit
+		return      // Should not be reached in subprocess
+	}
+
+	// Prepare to run the test in a subprocess
+	cmd := exec.Command(os.Args[0], "-test.run="+testName) // Will rerun only the current test function
+	cmd.Env = append(os.Environ(), "BE_FATAL_TESTER=1")    // Set marker for subprocess
+
+	// We need to pass through necessary env vars for the test runner itself,
+	// but clear/set specific ASSET_WATCHER_* vars within setupFunc in the subprocess.
+	// The setupFunc will be responsible for setting the environment that causes GetConfig to fail.
+
+	err := cmd.Run()
+	// Check if the command exited with a non-zero status, indicating log.Fatalf was likely called.
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		// ExitError and non-zero exit status means the program exited as expected.
+		// We could also check e.Sys().(syscall.WaitStatus).ExitStatus() == 1 if needed for more specific exit codes.
+		return // Test passed
+	}
+	// If err is nil, or it's an ExitError but with success (exit code 0), then GetConfig did not call log.Fatalf.
+	var output []byte
+	if e, ok := err.(*exec.ExitError); ok {
+		output = e.Stderr // Stderr often contains the log.Fatalf message
+	} else if err != nil { // Other error during cmd.Run
+		t.Fatalf("%s: GetConfig did not call log.Fatalf as expected. Command execution failed: %v. Output: %s", testName, err, output)
+		return
+	}
+
+	// If we reach here, cmd.Run() succeeded (exit code 0) or had an unexpected error.
+	t.Fatalf("%s: GetConfig did not call log.Fatalf as expected. Process exited cleanly or with an unexpected error. Output: %s", testName, output)
+}
+
+
+func TestGetConfig_MissingRequiredEnv(t *testing.T) {
+	runTestExpectingFatal(t, "TestGetConfig_MissingRequiredEnv", func() {
+		// Inside the subprocess, clear the required env var
+		// All other ASSET_WATCHER vars should ideally be cleared or set to defaults
+		// to ensure this is the specific condition causing failure.
+		// The `env` package will pick up other existing ASSET_WATCHER_* vars if not cleared.
+		os.Unsetenv("ASSET_WATCHER_ORG_ID")
+		os.Unsetenv("ASSET_WATCHER_DEBUG")
+		os.Unsetenv("ASSET_WATCHER_OUTPUT_FORMAT")
+		os.Unsetenv("ASSET_WATCHER_EXCLUDE_RESERVED")
+		os.Unsetenv("ASSET_WATCHER_EXCLUDE_PROJECTS")
+		os.Unsetenv("ASSET_WATCHER_INCLUDE_PROJECTS")
+	})
+}
+
+func TestGetConfig_ExcludeAndIncludeProjectsSet(t *testing.T) {
+	runTestExpectingFatal(t, "TestGetConfig_ExcludeAndIncludeProjectsSet", func() {
+		os.Setenv("ASSET_WATCHER_ORG_ID", "test-org-for-exclude-include") // Required
+		os.Setenv("ASSET_WATCHER_EXCLUDE_PROJECTS", "projA")
+		os.Setenv("ASSET_WATCHER_INCLUDE_PROJECTS", "projB")
+	})
+}
+
+func TestGetConfig_InvalidOutputFormat(t *testing.T) {
+	runTestExpectingFatal(t, "TestGetConfig_InvalidOutputFormat", func() {
+		os.Setenv("ASSET_WATCHER_ORG_ID", "test-org-for-invalid-format") // Required
+		os.Setenv("ASSET_WATCHER_OUTPUT_FORMAT", "invalid-format")
+		// Ensure other conflicting settings are not present
+		os.Unsetenv("ASSET_WATCHER_EXCLUDE_PROJECTS")
+		os.Unsetenv("ASSET_WATCHER_INCLUDE_PROJECTS")
+	})
+}
+
+// Helper function to check if a string contains a substring. (Not used with log.Fatalf tests directly anymore)
+func contains(s, substr string) bool {
+	return strings.Contains(s, substr)
+}

--- a/config_test.go
+++ b/config_test.go
@@ -203,7 +203,4 @@ func TestGetConfig_InvalidOutputFormat(t *testing.T) {
 	})
 }
 
-// Helper function to check if a string contains a substring. (Not used with log.Fatalf tests directly anymore)
-func contains(s, substr string) bool {
-	return strings.Contains(s, substr)
-}
+// (Removed unused `contains` function)

--- a/config_test.go
+++ b/config_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
-	"strings"
 	"testing"
 )
 
@@ -13,16 +12,16 @@ func setEnvVar(t *testing.T, key, value string) {
 	t.Helper()
 	originalValue, originalExists := os.LookupEnv(key)
 	if err := os.Setenv(key, value); err != nil {
-		t.Fatalf("Failed to set env var %s: %v", key, err)
+		t.Fatalf("failed to set env var %s: %v", key, err)
 	}
 	t.Cleanup(func() {
 		if originalExists {
 			if err := os.Setenv(key, originalValue); err != nil {
-				t.Errorf("Failed to restore env var %s: %v", key, err)
+				t.Errorf("failed to restore env var %s: %v", key, err)
 			}
 		} else {
 			if err := os.Unsetenv(key); err != nil {
-				t.Errorf("Failed to unset env var %s: %v", key, err)
+				t.Errorf("failed to unset env var %s: %v", key, err)
 			}
 		}
 	})
@@ -37,7 +36,7 @@ func clearEnvVar(t *testing.T, key string) {
 	t.Cleanup(func() {
 		if originalExists {
 			if err := os.Setenv(key, originalValue); err != nil {
-				t.Errorf("Failed to restore env var %s after clearing: %v", key, err)
+				t.Errorf("failed to restore env var %s after clearing: %v", key, err)
 			}
 		}
 	})
@@ -59,26 +58,25 @@ func TestGetConfig_Defaults(t *testing.T) {
 	// Defer cleanup of required var if it wasn't set before this test
 	defer clearEnvVar(t, "ASSET_WATCHER_ORG_ID")
 
-
 	cfg := GetConfig() // GetConfig calls log.Fatalf on error if ORG_ID is missing
 
 	if cfg.OrgID != "test-org-id-defaults" {
-		t.Errorf("Expected OrgID to be 'test-org-id-defaults', got '%s'", cfg.OrgID)
+		t.Errorf("expected OrgID to be 'test-org-id-defaults', got '%s'", cfg.OrgID)
 	}
 	if cfg.Debug != false {
-		t.Errorf("Expected Debug default to be false, got %t", cfg.Debug)
+		t.Errorf("expected Debug default to be false, got %t", cfg.Debug)
 	}
 	if cfg.OutputFormat != "table" {
-		t.Errorf("Expected OutputFormat default to be 'table', got '%s'", cfg.OutputFormat)
+		t.Errorf("expected OutputFormat default to be 'table', got '%s'", cfg.OutputFormat)
 	}
 	if cfg.ExcludeReserved != false {
-		t.Errorf("Expected ExcludeReserved default to be false, got %t", cfg.ExcludeReserved)
+		t.Errorf("expected ExcludeReserved default to be false, got %t", cfg.ExcludeReserved)
 	}
 	if cfg.ExcludeProjects != "" {
-		t.Errorf("Expected ExcludeProjects default to be empty string, got '%s'", cfg.ExcludeProjects)
+		t.Errorf("expected ExcludeProjects default to be empty string, got '%s'", cfg.ExcludeProjects)
 	}
 	if cfg.IncludeProjects != "" {
-		t.Errorf("Expected IncludeProjects default to be empty string, got '%s'", cfg.IncludeProjects)
+		t.Errorf("expected IncludeProjects default to be empty string, got '%s'", cfg.IncludeProjects)
 	}
 }
 
@@ -103,17 +101,17 @@ func TestGetConfig_LoadFromEnv(t *testing.T) {
 	cfg := GetConfig()
 
 	if !reflect.DeepEqual(*cfg, expectedConfig) {
-		t.Errorf("Expected config %+v, got %+v", expectedConfig, *cfg)
+		t.Errorf("expected config %+v, got %+v", expectedConfig, *cfg)
 	}
 }
 
 func TestGetConfig_LoadFromEnv_Include(t *testing.T) {
 	expectedConfig := Config{
 		OrgID:           "env-org-id-include",
-		Debug:           false, // Testing explicit false
+		Debug:           false,   // Testing explicit false
 		OutputFormat:    "table", // Testing explicit table
-		ExcludeReserved: false, // Testing explicit false
-		ExcludeProjects: "", 
+		ExcludeReserved: false,   // Testing explicit false
+		ExcludeProjects: "",
 		IncludeProjects: "proj3,proj4",
 	}
 
@@ -127,7 +125,7 @@ func TestGetConfig_LoadFromEnv_Include(t *testing.T) {
 	cfg := GetConfig()
 
 	if !reflect.DeepEqual(*cfg, expectedConfig) {
-		t.Errorf("Expected config %+v, got %+v", expectedConfig, *cfg)
+		t.Errorf("expected config %+v, got %+v", expectedConfig, *cfg)
 	}
 }
 
@@ -168,7 +166,6 @@ func runTestExpectingFatal(t *testing.T, testName string, setupFunc func()) {
 	// If we reach here, cmd.Run() succeeded (exit code 0) or had an unexpected error.
 	t.Fatalf("%s: GetConfig did not call log.Fatalf as expected. Process exited cleanly or with an unexpected error. Output: %s", testName, output)
 }
-
 
 func TestGetConfig_MissingRequiredEnv(t *testing.T) {
 	runTestExpectingFatal(t, "TestGetConfig_MissingRequiredEnv", func() {

--- a/output_test.go
+++ b/output_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStdout is a helper function to capture standard output.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	fn() // Execute the function whose output we want to capture
+
+	if err := w.Close(); err != nil {
+		if !strings.Contains(err.Error(), "file already closed") {
+			t.Logf("Error closing writer pipe: %v", err) 
+		}
+	}
+	os.Stdout = oldStdout 
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Logf("Error reading from pipe: %v", err) 
+	}
+	if err := r.Close(); err != nil {
+		t.Logf("Error closing reader pipe: %v", err) 
+	}
+	return buf.String()
+}
+
+// TestOutputToStdOutTable tests the outputToStdOutTable function.
+func TestOutputToStdOutTable(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil)) 
+	ctx := context.Background()
+
+	sampleAssets := []ProcessedAsset{
+		{Name: "Asset1", Location: "loc1", Project: "proj1", IPAddress: "1.1.1.1", Status: "ACTIVE", CreatedAt: "2023-01-01"},
+		{Name: "Asset2", Location: "loc2", Project: "proj2", IPAddress: "2.2.2.2", Status: "RESERVED", CreatedAt: "2023-01-02"},
+	}
+
+	// Expected header column names (keywords)
+	expectedHeaderKeywords := []string{"Display Name", "Location", "Project ID", "IP Address", "State", "Created At"}
+
+	t.Run("No assets", func(t *testing.T) {
+		output := captureStdout(t, func() {
+			outputToStdOutTable(ctx, logger, []ProcessedAsset{})
+		})
+		
+		// Check for header keywords
+		for _, keyword := range expectedHeaderKeywords {
+			if !strings.Contains(output, keyword) {
+				t.Errorf("Table header keyword '%s' not found in output with no assets. Output:\n%s", keyword, output)
+			}
+		}
+
+		lines := strings.Split(strings.TrimSpace(output), "\n")
+		// Expect at least 2 lines for header and separator, possibly more due to tabwriter.Debug
+		if len(lines) < 2 {
+			t.Errorf("Expected at least 2 lines for header and separator, got %d. Output:\n%s", len(lines), output)
+		}
+		
+		// Check that specific asset data is not present
+		if strings.Contains(output, "Asset1") || strings.Contains(output, "proj1") {
+			t.Errorf("Found asset data in output when no assets were provided. Output:\n%s", output)
+		}
+	})
+
+	t.Run("With assets", func(t *testing.T) {
+		output := captureStdout(t, func() {
+			outputToStdOutTable(ctx, logger, sampleAssets)
+		})
+
+		// Check for header keywords
+		for _, keyword := range expectedHeaderKeywords {
+			if !strings.Contains(output, keyword) {
+				t.Errorf("Table header keyword '%s' not found in output with assets. Output:\n%s", keyword, output)
+			}
+		}
+
+		// Check for asset details
+		for _, asset := range sampleAssets {
+			if !strings.Contains(output, asset.Name) {
+				t.Errorf("Asset name %s not found in table output. Output:\n%s", asset.Name, output)
+			}
+			if !strings.Contains(output, asset.Project) {
+				t.Errorf("Asset project %s not found in table output. Output:\n%s", asset.Project, output)
+			}
+			if !strings.Contains(output, asset.IPAddress) {
+				t.Errorf("Asset IPAddress %s not found in table output. Output:\n%s", asset.IPAddress, output)
+			}
+		}
+	})
+}
+
+// TestOutputToStdOutJSON tests the outputToStdOutJSON function.
+func TestOutputToStdOutJSON(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil)) 
+	ctx := context.Background()
+
+	sampleAssets := []ProcessedAsset{
+		{Name: "Asset1", Location: "loc1", Project: "proj1", IPAddress: "1.1.1.1", Status: "ACTIVE", CreatedAt: "2023-01-01"},
+		{Name: "Asset2", Location: "loc2", Project: "proj2", IPAddress: "2.2.2.2", Status: "RESERVED", CreatedAt: "2023-01-02"},
+	}
+
+	t.Run("No assets", func(t *testing.T) {
+		output := captureStdout(t, func() {
+			outputToStdOutJSON(ctx, logger, []ProcessedAsset{})
+		})
+
+		var unmarshalledOutput []ProcessedAsset
+		err := json.Unmarshal([]byte(output), &unmarshalledOutput)
+		if err != nil {
+			t.Fatalf("Output with no assets is not valid JSON: %v\nOutput was: %s", err, output)
+		}
+		if len(unmarshalledOutput) != 0 {
+			t.Errorf("Expected empty JSON array, got %d elements", len(unmarshalledOutput))
+		}
+	})
+
+	t.Run("With assets", func(t *testing.T) {
+		output := captureStdout(t, func() {
+			outputToStdOutJSON(ctx, logger, sampleAssets)
+		})
+
+		var processedOutput []ProcessedAsset
+		err := json.Unmarshal([]byte(output), &processedOutput)
+		if err != nil {
+			t.Fatalf("Output with assets is not valid JSON: %v\nOutput was: %s", err, output)
+		}
+
+		if len(processedOutput) != len(sampleAssets) {
+			t.Errorf("Expected %d assets in JSON output, got %d", len(sampleAssets), len(processedOutput))
+		}
+
+		for i, asset := range sampleAssets {
+			if i < len(processedOutput) {
+				if processedOutput[i].Name != asset.Name {
+					t.Errorf("Asset name mismatch in JSON output. Expected %s, got %s", asset.Name, processedOutput[i].Name)
+				}
+				if processedOutput[i].Project != asset.Project {
+					t.Errorf("Asset project mismatch in JSON output. Expected %s, got %s", asset.Project, processedOutput[i].Project)
+				}
+			}
+		}
+	})
+}

--- a/output_test.go
+++ b/output_test.go
@@ -17,7 +17,7 @@ func captureStdout(t *testing.T, fn func()) string {
 	oldStdout := os.Stdout
 	r, w, err := os.Pipe()
 	if err != nil {
-		t.Fatalf("Failed to create pipe: %v", err)
+		t.Fatalf("failed to create pipe: %v", err)
 	}
 	os.Stdout = w
 
@@ -25,24 +25,24 @@ func captureStdout(t *testing.T, fn func()) string {
 
 	if err := w.Close(); err != nil {
 		if !strings.Contains(err.Error(), "file already closed") {
-			t.Logf("Error closing writer pipe: %v", err) 
+			t.Logf("error closing writer pipe: %v", err)
 		}
 	}
-	os.Stdout = oldStdout 
+	os.Stdout = oldStdout
 
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, r); err != nil {
-		t.Logf("Error reading from pipe: %v", err) 
+		t.Logf("error reading from pipe: %v", err)
 	}
 	if err := r.Close(); err != nil {
-		t.Logf("Error closing reader pipe: %v", err) 
+		t.Logf("error closing reader pipe: %v", err)
 	}
 	return buf.String()
 }
 
 // TestOutputToStdOutTable tests the outputToStdOutTable function.
 func TestOutputToStdOutTable(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil)) 
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.Background()
 
 	sampleAssets := []ProcessedAsset{
@@ -57,23 +57,23 @@ func TestOutputToStdOutTable(t *testing.T) {
 		output := captureStdout(t, func() {
 			outputToStdOutTable(ctx, logger, []ProcessedAsset{})
 		})
-		
+
 		// Check for header keywords
 		for _, keyword := range expectedHeaderKeywords {
 			if !strings.Contains(output, keyword) {
-				t.Errorf("Table header keyword '%s' not found in output with no assets. Output:\n%s", keyword, output)
+				t.Errorf("table header keyword '%s' not found in output with no assets. Output:\n%s", keyword, output)
 			}
 		}
 
 		lines := strings.Split(strings.TrimSpace(output), "\n")
 		// Expect at least 2 lines for header and separator, possibly more due to tabwriter.Debug
 		if len(lines) < 2 {
-			t.Errorf("Expected at least 2 lines for header and separator, got %d. Output:\n%s", len(lines), output)
+			t.Errorf("expected at least 2 lines for header and separator, got %d. Output:\n%s", len(lines), output)
 		}
-		
+
 		// Check that specific asset data is not present
 		if strings.Contains(output, "Asset1") || strings.Contains(output, "proj1") {
-			t.Errorf("Found asset data in output when no assets were provided. Output:\n%s", output)
+			t.Errorf("found asset data in output when no assets were provided. Output:\n%s", output)
 		}
 	})
 
@@ -85,20 +85,20 @@ func TestOutputToStdOutTable(t *testing.T) {
 		// Check for header keywords
 		for _, keyword := range expectedHeaderKeywords {
 			if !strings.Contains(output, keyword) {
-				t.Errorf("Table header keyword '%s' not found in output with assets. Output:\n%s", keyword, output)
+				t.Errorf("table header keyword '%s' not found in output with assets. Output:\n%s", keyword, output)
 			}
 		}
 
 		// Check for asset details
 		for _, asset := range sampleAssets {
 			if !strings.Contains(output, asset.Name) {
-				t.Errorf("Asset name %s not found in table output. Output:\n%s", asset.Name, output)
+				t.Errorf("asset name %s not found in table output. Output:\n%s", asset.Name, output)
 			}
 			if !strings.Contains(output, asset.Project) {
-				t.Errorf("Asset project %s not found in table output. Output:\n%s", asset.Project, output)
+				t.Errorf("asset project %s not found in table output. Output:\n%s", asset.Project, output)
 			}
 			if !strings.Contains(output, asset.IPAddress) {
-				t.Errorf("Asset IPAddress %s not found in table output. Output:\n%s", asset.IPAddress, output)
+				t.Errorf("asset IPAddress %s not found in table output. Output:\n%s", asset.IPAddress, output)
 			}
 		}
 	})
@@ -106,7 +106,7 @@ func TestOutputToStdOutTable(t *testing.T) {
 
 // TestOutputToStdOutJSON tests the outputToStdOutJSON function.
 func TestOutputToStdOutJSON(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil)) 
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.Background()
 
 	sampleAssets := []ProcessedAsset{
@@ -122,10 +122,10 @@ func TestOutputToStdOutJSON(t *testing.T) {
 		var unmarshalledOutput []ProcessedAsset
 		err := json.Unmarshal([]byte(output), &unmarshalledOutput)
 		if err != nil {
-			t.Fatalf("Output with no assets is not valid JSON: %v\nOutput was: %s", err, output)
+			t.Fatalf("output with no assets is not valid JSON: %v\nOutput was: %s", err, output)
 		}
 		if len(unmarshalledOutput) != 0 {
-			t.Errorf("Expected empty JSON array, got %d elements", len(unmarshalledOutput))
+			t.Errorf("expected empty JSON array, got %d elements", len(unmarshalledOutput))
 		}
 	})
 
@@ -137,20 +137,20 @@ func TestOutputToStdOutJSON(t *testing.T) {
 		var processedOutput []ProcessedAsset
 		err := json.Unmarshal([]byte(output), &processedOutput)
 		if err != nil {
-			t.Fatalf("Output with assets is not valid JSON: %v\nOutput was: %s", err, output)
+			t.Fatalf("output with assets is not valid JSON: %v\nOutput was: %s", err, output)
 		}
 
 		if len(processedOutput) != len(sampleAssets) {
-			t.Errorf("Expected %d assets in JSON output, got %d", len(sampleAssets), len(processedOutput))
+			t.Errorf("expected %d assets in JSON output, got %d", len(sampleAssets), len(processedOutput))
 		}
 
 		for i, asset := range sampleAssets {
 			if i < len(processedOutput) {
 				if processedOutput[i].Name != asset.Name {
-					t.Errorf("Asset name mismatch in JSON output. Expected %s, got %s", asset.Name, processedOutput[i].Name)
+					t.Errorf("asset name mismatch in JSON output. Expected %s, got %s", asset.Name, processedOutput[i].Name)
 				}
 				if processedOutput[i].Project != asset.Project {
-					t.Errorf("Asset project mismatch in JSON output. Expected %s, got %s", asset.Project, processedOutput[i].Project)
+					t.Errorf("asset project mismatch in JSON output. Expected %s, got %s", asset.Project, processedOutput[i].Project)
 				}
 			}
 		}

--- a/processor_test.go
+++ b/processor_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"context" 
+	"io"      
+	"log/slog" 
+	"reflect"
+	"testing"
+	"time" 
+
+	"cloud.google.com/go/asset/apiv1/assetpb"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb" 
+)
+
+func TestSplitString(t *testing.T) {
+	tests := []struct {
+		name      string
+		s         string
+		separator string
+		want      []string
+	}{
+		{name: "empty string", s: "", separator: ",", want: []string{}},
+		{name: "string with no separators", s: "abc", separator: ",", want: []string{"abc"}},
+		{name: "string with leading/trailing spaces and spaces around separators", s: "  abc  ,  def  ,ghi,jkl  ", separator: ",", want: []string{"abc", "def", "ghi", "jkl"}},
+		{name: "string with multiple separators", s: "abc,,def", separator: ",", want: []string{"abc", "def"}},
+		{name: "string with only separators", s: ",,,", separator: ",", want: []string{}},
+		{name: "string with different separator", s: "abc;def;ghi", separator: ";", want: []string{"abc", "def", "ghi"}},
+		{name: "string with multiple character separator", s: "abc<sep>def<sep>ghi", separator: "<sep>", want: []string{"abc", "def", "ghi"}},
+		{name: "empty string with spaces", s: "   ", separator: ",", want: []string{}},
+		{name: "separator at the beginning", s: ",abc,def", separator: ",", want: []string{"abc", "def"}},
+		{name: "separator at the end", s: "abc,def,", separator: ",", want: []string{"abc", "def"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := splitString(tt.s, tt.separator); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("splitString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetIPAddress(t *testing.T) {
+	tests := []struct {
+		name  string
+		asset *assetpb.ResourceSearchResult
+		want  string
+	}{
+		{name: "asset with IP address", asset: &assetpb.ResourceSearchResult{AdditionalAttributes: &structpb.Struct{Fields: map[string]*structpb.Value{"address": structpb.NewStringValue("192.168.1.1")}}}, want: "192.168.1.1"},
+		{name: "asset with no address field", asset: &assetpb.ResourceSearchResult{AdditionalAttributes: &structpb.Struct{Fields: map[string]*structpb.Value{"other_field": structpb.NewStringValue("some_value")}}}, want: "N/A"},
+		{name: "asset with address field not a string", asset: &assetpb.ResourceSearchResult{AdditionalAttributes: &structpb.Struct{Fields: map[string]*structpb.Value{"address": structpb.NewNumberValue(123)}}}, want: "N/A"},
+		{name: "asset with nil AdditionalAttributes", asset: &assetpb.ResourceSearchResult{AdditionalAttributes: nil}, want: "N/A"},
+		{name: "asset with nil Fields in AdditionalAttributes", asset: &assetpb.ResourceSearchResult{AdditionalAttributes: &structpb.Struct{Fields: nil}}, want: "N/A"},
+		{name: "asset with address field being nil structpb.Value", asset: &assetpb.ResourceSearchResult{AdditionalAttributes: &structpb.Struct{Fields: map[string]*structpb.Value{"address": nil}}}, want: "N/A"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getIPAddress(tt.asset); got != tt.want {
+				t.Errorf("getIPAddress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetProjectID(t *testing.T) {
+	tests := []struct {
+		name  string
+		asset *assetpb.ResourceSearchResult
+		want  string
+	}{
+		{name: "asset with correct project ID", asset: &assetpb.ResourceSearchResult{ParentAssetType: "cloudresourcemanager.googleapis.com/Project", ParentFullResourceName: "//cloudresourcemanager.googleapis.com/projects/my-project-123"}, want: "my-project-123"},
+		{name: "asset with different parent asset type", asset: &assetpb.ResourceSearchResult{ParentAssetType: "compute.googleapis.com/Instance", ParentFullResourceName: "//cloudresourcemanager.googleapis.com/projects/another-project-456"}, want: "N/A"},
+		{name: "asset with project parent type but empty resource name", asset: &assetpb.ResourceSearchResult{ParentAssetType: "cloudresourcemanager.googleapis.com/Project", ParentFullResourceName: ""}, want: ""}, 
+		{name: "asset with project parent type but malformed resource name (no slashes)", asset: &assetpb.ResourceSearchResult{ParentAssetType: "cloudresourcemanager.googleapis.com/Project", ParentFullResourceName: "my-project-malformed"}, want: "my-project-malformed"},
+		{name: "asset with project parent type but resource name is just slashes", asset: &assetpb.ResourceSearchResult{ParentAssetType: "cloudresourcemanager.googleapis.com/Project", ParentFullResourceName: "//"}, want: ""}, 
+		{name: "asset with project parent type, resource name ends with slash", asset: &assetpb.ResourceSearchResult{ParentAssetType: "cloudresourcemanager.googleapis.com/Project", ParentFullResourceName: "//cloudresourcemanager.googleapis.com/projects/project-ending-slash/"}, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getProjectID(tt.asset); got != tt.want {
+				t.Errorf("getProjectID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func newTestAssetHelper(name, projectID, state, ipAddress string, createTime time.Time) *assetpb.ResourceSearchResult {
+	asset := &assetpb.ResourceSearchResult{
+		DisplayName: name,
+		State:       state,
+		CreateTime:  timestamppb.New(createTime),
+	}
+	if projectID != "" {
+		asset.ParentAssetType = "cloudresourcemanager.googleapis.com/Project"
+		asset.ParentFullResourceName = "//cloudresourcemanager.googleapis.com/projects/" + projectID
+	} else {
+		asset.ParentAssetType = "organizations/org-id" 
+		asset.ParentFullResourceName = "//cloudresourcemanager.googleapis.com/organizations/org-id"
+	}
+
+	if ipAddress != "N/A" && ipAddress != "" {
+		asset.AdditionalAttributes = &structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				"address": structpb.NewStringValue(ipAddress),
+			},
+		}
+	} else {
+		asset.AdditionalAttributes = &structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				"other_info": structpb.NewStringValue("no_ip"),
+			},
+		}
+	}
+	return asset
+}
+
+func TestProcessAssets_Conceptual(t *testing.T) {
+	// This function remains as a conceptual placeholder due to difficulties in mocking
+	// the concrete `*asset.ResourceSearchResultIterator` needed by `ProcessAssets`.
+	// Full testing of `ProcessAssets` with varied inputs would require refactoring
+	// `processor.go` or using integration tests.
+
+	ctx := context.Background()                             // Required for NewAssetProcessor
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil)) // Required for NewAssetProcessor
+
+	baseTime := time.Date(2024, 1, 10, 12, 0, 0, 0, time.UTC)
+	expectedFormattedTime := baseTime.Format("2006-01-02 15:04:05")
+	
+	// Example asset for demonstrating ProcessedAsset mapping
+	assetActive := newTestAssetHelper("active-asset", "proj-A", "ACTIVE", "1.2.3.4", baseTime)
+	// Unused asset variables removed: assetReserved, assetExcludedProj, assetIncludedProj
+
+	t.Log("TestProcessAssets_Conceptual: This test is a conceptual placeholder.")
+	t.Log("Direct unit testing of ProcessAssets with controlled asset inputs is not currently feasible without refactoring processor.go or using integration tests.")
+	t.Log("The function relies on a concrete iterator type from the GCP SDK, which cannot be easily mocked with a slice of test data.")
+
+	// Test the instantiation of AssetProcessor (very minor)
+	cfgForProcessor := &Config{OrgID: "test-org"}
+	_ = NewAssetProcessor(ctx, logger, cfgForProcessor) // ap variable removed as it was unused
+
+	// Test how default IncludeProjects/ExcludeProjects from config are split
+	if len(splitString(cfgForProcessor.IncludeProjects, ",")) != 0 {
+		t.Errorf("Expected default IncludeProjects to result in empty slice, got %d", len(splitString(cfgForProcessor.IncludeProjects, ",")))
+	}
+	if len(splitString(cfgForProcessor.ExcludeProjects, ",")) != 0 {
+		t.Errorf("Expected default ExcludeProjects to result in empty slice, got %d", len(splitString(cfgForProcessor.ExcludeProjects, ",")))
+	}
+	
+	// Test the manual mapping part for a single asset, simulating what happens inside ProcessAssets loop
+	singleAsset := assetActive // Use the one defined asset
+	projectID := getProjectID(singleAsset)
+	ipAddress := getIPAddress(singleAsset)
+	
+	pa := ProcessedAsset{
+		Name:      singleAsset.GetDisplayName(),
+		Location:  singleAsset.GetLocation(),
+		Project:   projectID,
+		IPAddress: ipAddress,
+		Status:    singleAsset.GetState(),
+		CreatedAt: singleAsset.GetCreateTime().AsTime().Format("2006-01-02 15:04:05"),
+	}
+
+	if pa.Name != "active-asset" { t.Errorf("ProcessedAsset mapping error for Name") }
+	if pa.Project != "proj-A" { t.Errorf("ProcessedAsset mapping error for Project") }
+	if pa.IPAddress != "1.2.3.4" { t.Errorf("ProcessedAsset mapping error for IPAddress") }
+	if pa.Status != "ACTIVE" { t.Errorf("ProcessedAsset mapping error for Status") }
+	if pa.CreatedAt != expectedFormattedTime { t.Errorf("ProcessedAsset mapping error for CreatedAt: got %s, want %s", pa.CreatedAt, expectedFormattedTime) }
+
+	t.Log("Verified ProcessedAsset struct population for a single manually-mapped asset.")
+}


### PR DESCRIPTION
This commit introduces a foundational set of unit tests for the asset-watcher utility.

Tests have been added for the following packages and functionalities:

- **config.go**:
    - Verifies correct loading of configuration from environment variables.
    - Checks handling of default values.
    - Ensures appropriate error handling for missing required variables and conflicting configurations (e.g., include and exclude projects set simultaneously).
    - Validates error paths for invalid output format values.

- **processor.go**:
    - Tests the `splitString` utility function with various inputs.
    - Tests `getIPAddress` for correct IP address extraction from asset data.
    - Tests `getProjectID` for correct project ID extraction.
    - Includes a placeholder test for `ProcessAssets` acknowledging the current limitation in directly testing this function with varied asset inputs due to its dependency on a concrete SDK iterator.

- **output.go**:
    - Tests `outputToStdOutTable` for correct table structure output, including headers and asset data, for both empty and populated asset lists.
    - Tests `outputToStdOutJSON` for valid JSON output, for both empty and populated asset lists.
    - Standard output is captured to verify the content and structure of the generated output.

These tests improve the robustness and maintainability of asset-watcher by providing a safety net for future changes and refactoring.