### PR TITLE
chore: update dependabot schedule and update README

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
       day: friday
       time: "21:45"
     open-pull-requests-limit: 1
@@ -16,7 +16,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
       day: friday
       time: "21:45"
     labels:
@@ -28,7 +28,7 @@ updates:
   - package-ecosystem: docker
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
       day: friday
       time: "21:45"
     labels:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ brew upgrade asset-watcher
 
 Download the pre-compiled binaries from [the releases page](https://github.com/andreygrechin/asset-watcher/releases/) and copy them to a desired location.
 
+## Required permissions
+
+```shell
+gcloud services enable cloudasset.googleapis.com
+gcloud config set project <your-project-id-where-asset-api-is-enabled>
+# set quota project
+```
+
+To run the tool, you need to have the following permissions:
+
+- `resourcemanager.projects.get`
+- `resourcemanager.projects.list`
+
 ## Usage
 
 ### Run as a binary


### PR DESCRIPTION
This pull request includes updates to the configuration for Dependabot and documentation enhancements for the `asset-watcher` tool. The most important changes involve changing the update interval for several ecosystems in Dependabot and adding required permissions to the `README.md`.

### Configuration updates for Dependabot:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L9-R9): Changed the update interval for `gomod`, `github-actions`, and `docker` ecosystems from daily to weekly. This aligns with a more manageable update schedule. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L9-R9) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L19-R19) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L31-R31)

### Documentation enhancements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R37-R49): Added a "Required permissions" section, including commands for enabling the `cloudasset.googleapis.com` service and setting the project configuration, as well as listing the necessary permissions (`resourcemanager.projects.get`, `resourcemanager.projects.list`) for running the `asset-watcher` tool.